### PR TITLE
TAG-229 Begrenser antall innsendte skjema over en gitt periode

### DIFF
--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
@@ -2,7 +2,6 @@ package no.nav.tag.kontaktskjema;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -11,8 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 
 @CrossOrigin(origins = {"https://tjenester.nav.no", "https://tjenester-q1.nav.no", "https://tjenester-t1.nav.no"})
 @RestController
@@ -35,6 +32,9 @@ public class KontaktskjemaController {
         }
         try {
             kontaktskjema.setOpprettet(LocalDateTime.now());
+            if(repository.findAllNewerThan(LocalDateTime.now().minusMinutes(10)).size() >= 10) {
+                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+            };
             repository.save(kontaktskjema);
             log.info("Vellykket innsending.");
             return ResponseEntity.ok(HttpStatus.OK);

--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
@@ -1,6 +1,16 @@
 package no.nav.tag.kontaktskjema;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface KontaktskjemaRepository extends CrudRepository<Kontaktskjema, Integer> {
+    
+    
+    @Query("SELECT k.* FROM Kontaktskjema k WHERE k.opprettet > :created")
+    public Collection<Kontaktskjema> findAllNewerThan(@Param(value = "created") LocalDateTime created);
+    
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
@@ -4,9 +4,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static no.nav.tag.kontaktskjema.TestData.lagKontaktskjema;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -20,5 +24,15 @@ public class KontaktskjemaControllerTest {
         Kontaktskjema kontaktskjema = lagKontaktskjema();
         kontaktskjema.setId(52);
         kontaktskjemaController.meldInteresse(kontaktskjema);
+    }
+
+    @Test
+    public void skalReturnere429VedForMangeInnsendinger() {
+        for (int i=0; i<10; i++) {
+            kontaktskjemaController.meldInteresse(lagKontaktskjema());
+        }
+
+        ResponseEntity result = kontaktskjemaController.meldInteresse(lagKontaktskjema());
+        assertThat(result.getStatusCode(), is(HttpStatus.TOO_MANY_REQUESTS));
     }
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
@@ -1,0 +1,37 @@
+package no.nav.tag.kontaktskjema;
+
+import static no.nav.tag.kontaktskjema.TestData.lagKontaktskjema;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class KontaktskjemaRepositoryTest {
+
+    @Autowired
+    private KontaktskjemaRepository kontaktskjemaRepository;
+
+    @Test
+    public void skalHenteBasertPaDato() {
+        Kontaktskjema skjema1 = lagKontaktskjema();
+        skjema1.setOpprettet(LocalDateTime.now().minusDays(3));
+
+        Kontaktskjema skjema2 = lagKontaktskjema();
+        skjema2.setOpprettet(LocalDateTime.now().minusDays(1));
+        kontaktskjemaRepository.save(skjema1);
+        kontaktskjemaRepository.save(skjema2);
+        
+        assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now().minusDays(4)).size(), is(2));
+        assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now().minusDays(2)).size(), is(1));
+        assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now()).size(), is(0));
+    }
+
+}


### PR DESCRIPTION
Enkel funksjonalitet som hindrer innsending av skjema dersom antall skjemaer nylig har overskredet en viss grense. Foreløpig er denne satt til ti skjemaer siste ti minutter, men både antall og tidsvindu kan enkelt justeres.
Returnerer nå `HttpStatus.TOO_MANY_REQUESTS` hvis grensen er overskredet.
Denne funksjonaliteten begrenser hvor mange skjemaer vi får inn, og dermed også hvor mange oppgaver som vil bli opprettet i Gsak.
Merk at det foreløpig ikke ligger noen metrikker eller varsler på dette, så vi vil ikke uten videre oppdage at begrensningen har slått inn.