### PR TITLE
Fjerner mulighet til å sette id og opprettet i APIet

### DIFF
--- a/src/main/java/no/nav/tag/kontaktskjema/Kontaktskjema.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/Kontaktskjema.java
@@ -5,14 +5,19 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Data
 @Builder
 public class Kontaktskjema {
+
     @Id
+    @JsonIgnore
     private Integer id;
+    @JsonIgnore
     private LocalDateTime opprettet;
     private String fylke;
     private String kommune;

--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
@@ -2,7 +2,6 @@ package no.nav.tag.kontaktskjema;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -11,8 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 
 @CrossOrigin(origins = {"https://tjenester.nav.no", "https://tjenester-q1.nav.no", "https://tjenester-t1.nav.no"})
 @RestController
@@ -30,9 +27,6 @@ public class KontaktskjemaController {
     public ResponseEntity meldInteresse(
             @RequestBody Kontaktskjema kontaktskjema
     ) {
-        if (kontaktskjema.getId() != null) {
-            throw new KontaktskjemaException("Innsendt kontaktskjema skal ikke ha satt id.");
-        }
         try {
             kontaktskjema.setOpprettet(LocalDateTime.now());
             repository.save(kontaktskjema);

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
@@ -15,10 +15,8 @@ public class KontaktskjemaControllerTest {
     @Autowired
     KontaktskjemaController kontaktskjemaController;
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void skalFeileVedLagringAvKontaktskjemaMedForhandsdefinertId() {
-        Kontaktskjema kontaktskjema = lagKontaktskjema();
-        kontaktskjema.setId(52);
-        kontaktskjemaController.meldInteresse(kontaktskjema);
+        kontaktskjemaController.meldInteresse(lagKontaktskjema());
     }
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaControllerTest.java
@@ -16,7 +16,7 @@ public class KontaktskjemaControllerTest {
     KontaktskjemaController kontaktskjemaController;
 
     @Test
-    public void skalFeileVedLagringAvKontaktskjemaMedForhandsdefinertId() {
+    public void skalLagreKontaktskjemaOk() {
         kontaktskjemaController.meldInteresse(lagKontaktskjema());
     }
 }


### PR DESCRIPTION
Det er ikke meningen at bruker skal kunne oppgi id og dato, og ved å fjerne det fra APIet trenger vi ikke lenger å kaste exception dersom noen forsøker å bruke disse feltene.
Da kan vi også vurdere å la være å sette datoen til `LocalDateTime.now()` og overlate dette til databasen. Det kommer an på hvor vi ønsker å ha logikken, og hvilket tidspunkt det er mest riktig å bruke mtp. time skew mellom instanser