### PR TITLE
Støtte for lokal profil

### DIFF
--- a/src/main/java/no/nav/tag/kontaktskjema/DataSourceConfiguration.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/DataSourceConfiguration.java
@@ -9,8 +9,9 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import javax.sql.DataSource;
 
 @Configuration
-@Profile({"prod", "preprod", "uthenting"})
+@Profile({"prod", "preprod", "uthenting", "local"})
 public class DataSourceConfiguration {
+
     @Value("${db_url}")
     private String url;
     @Value("${db_username}")

--- a/src/main/java/no/nav/tag/kontaktskjema/DataSourceConfiguration.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/DataSourceConfiguration.java
@@ -10,7 +10,7 @@ import javax.sql.DataSource;
 
 @Configuration
 @Profile({"prod", "preprod", "uthenting"})
-public class PostgresDataSourceConfiguration {
+public class DataSourceConfiguration {
     @Value("${db_url}")
     private String url;
     @Value("${db_username}")

--- a/src/main/java/no/nav/tag/kontaktskjema/PostgresDataSourceConfiguration.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/PostgresDataSourceConfiguration.java
@@ -21,7 +21,6 @@ public class PostgresDataSourceConfiguration {
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setDriverClassName("org.postgresql.Driver");
         dataSource.setUrl(url);
         dataSource.setUsername(username);
         dataSource.setPassword(password);

--- a/src/main/java/no/nav/tag/kontaktskjema/SwaggerConfig.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/SwaggerConfig.java
@@ -14,7 +14,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
 @EnableSwagger2
-@Profile({"preprod", "dev"})
+@Profile({"preprod", "dev", "local"})
 public class SwaggerConfig {
 
     @Bean


### PR DESCRIPTION
Legger inn støtte for lokal profil, så det er mulig å skille mellom dev-profil (som brukes ved testing, har inmem-database og har delt oppsett mellom alle utviklere) og en lokal profil som kan brukes ved kjøretid lokalt (f.eks. mot standalone database) 