### PR TITLE
Forenkler tester

### DIFF
--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaController.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 @Slf4j
 public class KontaktskjemaController {
 
+    static final int MAX_INNSENDINGER_PR_TI_MIN = 10;
     private final KontaktskjemaRepository repository;
 
     @Autowired
@@ -32,7 +33,7 @@ public class KontaktskjemaController {
         }
         try {
             kontaktskjema.setOpprettet(LocalDateTime.now());
-            if(repository.findAllNewerThan(LocalDateTime.now().minusMinutes(10)).size() >= 10) {
+            if(repository.findAllNewerThan(LocalDateTime.now().minusMinutes(10)).size() >= MAX_INNSENDINGER_PR_TI_MIN) {
                 return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
             };
             repository.save(kontaktskjema);

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
@@ -1,15 +1,17 @@
 package no.nav.tag.kontaktskjema;
 
 import static no.nav.tag.kontaktskjema.TestData.lagKontaktskjema;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.time.LocalDateTime;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -19,19 +21,40 @@ public class KontaktskjemaRepositoryTest {
     @Autowired
     private KontaktskjemaRepository kontaktskjemaRepository;
 
+    @After
+    public void tearDown() {
+        kontaktskjemaRepository.deleteAll();
+    }
+    
+    @Test
+    public void skalLagreOgHenteUt() {
+        Kontaktskjema lagretSkjema = kontaktskjemaRepository.save(lagKontaktskjema());
+
+        assertThat(kontaktskjemaRepository.findById(lagretSkjema.getId()).isPresent(), is(true));
+    }
+
+    @Test(expected=DbActionExecutionException.class)
+    public void skalFeileHvisKommuneErForLang() {
+        Kontaktskjema kontaktskjema = lagKontaktskjema();
+        kontaktskjema.setKommunenr("12345");
+        kontaktskjemaRepository.save(kontaktskjema);
+    }
+    
     @Test
     public void skalHenteBasertPaDato() {
-        Kontaktskjema skjema1 = lagKontaktskjema();
-        skjema1.setOpprettet(LocalDateTime.now().minusDays(3));
+        kontaktskjemaRepository.save(skjemaMedDato(LocalDateTime.now().minusDays(3)));
+        kontaktskjemaRepository.save(skjemaMedDato(LocalDateTime.now().minusDays(1)));
 
-        Kontaktskjema skjema2 = lagKontaktskjema();
-        skjema2.setOpprettet(LocalDateTime.now().minusDays(1));
-        kontaktskjemaRepository.save(skjema1);
-        kontaktskjemaRepository.save(skjema2);
-        
         assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now().minusDays(4)).size(), is(2));
         assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now().minusDays(2)).size(), is(1));
         assertThat(kontaktskjemaRepository.findAllNewerThan(LocalDateTime.now()).size(), is(0));
     }
 
+    private Kontaktskjema skjemaMedDato(LocalDateTime opprettetTidspunkt) {
+        Kontaktskjema skjema1 = lagKontaktskjema();
+        skjema1.setOpprettet(opprettetTidspunkt);
+        return skjema1;
+    }
+
+    
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakSchedulerTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakSchedulerTest.java
@@ -19,7 +19,7 @@ public class GsakSchedulerTest {
 
     @Test
     public void skalFeileVedLagringAvKontaktskjemaMedForhandsdefinertId() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(1500);
         assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM SHEDLOCK", Integer.class), is(1));
     }
 

--- a/src/test/java/no/nav/tag/kontaktskjema/uthenting/UthentingUtilsTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/uthenting/UthentingUtilsTest.java
@@ -2,24 +2,16 @@ package no.nav.tag.kontaktskjema.uthenting;
 
 import no.nav.tag.kontaktskjema.Kontaktskjema;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.EMPTY_MAP;
 import static no.nav.tag.kontaktskjema.uthenting.UthentingUtils.MELDING;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
 public class UthentingUtilsTest {
-
-    @Autowired
-    private UthentingUtils uthentingUtils;
 
     @Test
     public void skalOversetteKontaktskjemaTilRiktigUthenting() {
@@ -72,7 +64,7 @@ public class UthentingUtilsTest {
         usorterteKontaktskjemaer.add(Kontaktskjema.builder().id(5).build());
         usorterteKontaktskjemaer.add(Kontaktskjema.builder().id(0).build());
 
-        List<KontaktskjemaUthenting> uthentinger = uthentingUtils.lagSorterteUthentinger(usorterteKontaktskjemaer);
+        List<KontaktskjemaUthenting> uthentinger = new UthentingUtils(EMPTY_MAP).lagSorterteUthentinger(usorterteKontaktskjemaer);
         List<Integer> ider = uthentinger.stream()
                 .map(KontaktskjemaUthenting::getId)
                 .collect(Collectors.toList());


### PR DESCRIPTION
Fjerner SpringBootTest der det ikke er nødvendig. Da går testene vesentlig raskere og gir mindre kompleksitet ved at vi slipper å forholde oss til Spring, den faktiske databaselogikken og tilstand i databasen på tvers av tester:
- KontaktskjemaControllerTest trenger ikke teste helt ned til databasen, vi kan mocke repository og likevel få testet at oppførsel og returverdier i Controlleren fungerer
- Lar i stedet KontaktskjemaRepositoryTest teste ekte databaseoppførsel gjennom Spring. Jeg la til noen flere enkle tester her.
- UthentingUtilsTest trenger heller ikke Spring til noe for å teste det den skal.