### PR TITLE
Oppgavebatch

### DIFF
--- a/src/main/java/no/nav/tag/kontaktskjema/DateProvider.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/DateProvider.java
@@ -2,6 +2,9 @@ package no.nav.tag.kontaktskjema;
 
 import java.time.LocalDateTime;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class DateProvider {
 
     public LocalDateTime now() {

--- a/src/main/java/no/nav/tag/kontaktskjema/DateProvider.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/DateProvider.java
@@ -1,0 +1,11 @@
+package no.nav.tag.kontaktskjema;
+
+import java.time.LocalDateTime;
+
+public class DateProvider {
+
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
@@ -12,7 +12,7 @@ public interface KontaktskjemaRepository extends CrudRepository<Kontaktskjema, I
     @Query("SELECT k.* FROM Kontaktskjema k WHERE k.opprettet > :created")
     public Collection<Kontaktskjema> findAllNewerThan(@Param(value = "created") LocalDateTime created);
     
-    @Query("SELECT k.* FROM Kontaktskjema k WHERE NOT EXISTS (SELECT g.id FROM GSAK_OPPGAVE g WHERE k.id = g.kontaktskjema_id)")
+    @Query("SELECT k.* FROM Kontaktskjema k WHERE NOT EXISTS (SELECT g.id FROM GSAK_OPPGAVE g WHERE k.id = g.kontaktskjema_id AND g.status <> 'FEILET')")
     public Collection<Kontaktskjema> findAllWithNoGsakOppgave();
     
 }

--- a/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/KontaktskjemaRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface KontaktskjemaRepository extends CrudRepository<Kontaktskjema, Integer> {
     
-    
     @Query("SELECT k.* FROM Kontaktskjema k WHERE k.opprettet > :created")
     public Collection<Kontaktskjema> findAllNewerThan(@Param(value = "created") LocalDateTime created);
+    
+    @Query("SELECT k.* FROM Kontaktskjema k WHERE NOT EXISTS (SELECT g.id FROM GSAK_OPPGAVE g WHERE k.id = g.kontaktskjema_id)")
+    public Collection<Kontaktskjema> findAllWithNoGsakOppgave();
     
 }

--- a/src/main/java/no/nav/tag/kontaktskjema/Transactor.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/Transactor.java
@@ -1,0 +1,32 @@
+package no.nav.tag.kontaktskjema;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class Transactor {
+
+    private final TransactionTemplate transactionTemplate;
+
+    public Transactor(PlatformTransactionManager platformTransactionManager) {
+        this.transactionTemplate = new TransactionTemplate(platformTransactionManager);
+    }
+
+    public void inTransaction(InTransaction inTransaction) {
+        transactionTemplate.execute(transactionStatus -> {
+            try {
+                inTransaction.run();
+                return null;
+            } catch (Throwable throwable) {
+                throw new RuntimeException(throwable);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    public interface InTransaction {
+        void run() throws Throwable;
+    }
+
+}

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
@@ -13,5 +13,11 @@ public class GsakOppgave {
     private Integer id;
     private Integer kontaktskjemaId;
     private Integer gsakId;
-    private String gsakStatus;
+    private OppgaveStatus status;
+    
+    public enum OppgaveStatus {
+        DISABLED,
+        OK,
+        FEILET
+    }
 }

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
@@ -1,0 +1,17 @@
+package no.nav.tag.kontaktskjema.gsak;
+
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+
+@Data
+@Builder
+public class GsakOppgave {
+
+    @Id
+    private Integer id;
+    private Integer kontaktskjemaId;
+    private Integer gsakId;
+    private String gsakStatus;
+}

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgave.java
@@ -1,8 +1,10 @@
 package no.nav.tag.kontaktskjema.gsak;
 
-
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.Id;
 
 @Data
@@ -14,6 +16,7 @@ public class GsakOppgave {
     private Integer kontaktskjemaId;
     private Integer gsakId;
     private OppgaveStatus status;
+    private LocalDateTime opprettet;
     
     public enum OppgaveStatus {
         DISABLED,

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
@@ -3,6 +3,7 @@ package no.nav.tag.kontaktskjema.gsak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import no.nav.tag.kontaktskjema.DateProvider;
 import no.nav.tag.kontaktskjema.Kontaktskjema;
 import no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus;
 
@@ -11,11 +12,15 @@ public class GsakOppgaveForSkjema {
     @Autowired
     GsakOppgaveRepository oppgaveRepository;
 
+    @Autowired
+    DateProvider dateProvider;
+
     @Transactional
     public void opprettOppgaveOgLagreStatus(Kontaktskjema lagKontaktskjema) {
         oppgaveRepository.save(new GsakOppgave.GsakOppgaveBuilder()
                 .kontaktskjemaId(lagKontaktskjema.getId())
                 .status(OppgaveStatus.DISABLED)
+                .opprettet(dateProvider.now())
                 .build());
     }
 

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
@@ -1,0 +1,23 @@
+package no.nav.tag.kontaktskjema.gsak;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import no.nav.tag.kontaktskjema.Kontaktskjema;
+import no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus;
+
+public class GsakOppgaveForSkjema {
+
+    @Autowired
+    GsakOppgaveRepository oppgaveRepository;
+
+    @Transactional
+    public void opprettOppgaveOgLagreStatus(Kontaktskjema lagKontaktskjema) {
+        oppgaveRepository.save(new GsakOppgave.GsakOppgaveBuilder()
+                .kontaktskjemaId(lagKontaktskjema.getId())
+                .status(OppgaveStatus.DISABLED)
+                .build());
+    }
+
+
+}

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjema.java
@@ -1,13 +1,24 @@
 package no.nav.tag.kontaktskjema.gsak;
 
+import static no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus.DISABLED;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.AllArgsConstructor;
 import no.nav.tag.kontaktskjema.DateProvider;
 import no.nav.tag.kontaktskjema.Kontaktskjema;
 import no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus;
 
+@Component
 public class GsakOppgaveForSkjema {
+
+    @AllArgsConstructor
+    private class Behandlingsresultat {
+        private OppgaveStatus status;
+        private Integer gsakId;
+    }
 
     @Autowired
     GsakOppgaveRepository oppgaveRepository;
@@ -16,12 +27,19 @@ public class GsakOppgaveForSkjema {
     DateProvider dateProvider;
 
     @Transactional
-    public void opprettOppgaveOgLagreStatus(Kontaktskjema lagKontaktskjema) {
+    public void opprettOppgaveOgLagreStatus(Kontaktskjema kontaktskjema) {
+        Behandlingsresultat behandlingsresultat = opprettOppgaveIGsak(kontaktskjema);
         oppgaveRepository.save(new GsakOppgave.GsakOppgaveBuilder()
-                .kontaktskjemaId(lagKontaktskjema.getId())
-                .status(OppgaveStatus.DISABLED)
+                .kontaktskjemaId(kontaktskjema.getId())
+                .status(behandlingsresultat.status)
                 .opprettet(dateProvider.now())
+                .gsakId(behandlingsresultat.gsakId)
                 .build());
+    }
+
+    private Behandlingsresultat opprettOppgaveIGsak(Kontaktskjema kontaktskjema) {
+        // TODO Implementere reelt kall mot gsak med støtte for OK og FEIL
+        return new Behandlingsresultat(DISABLED, null);
     }
 
 

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepository.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepository.java
@@ -1,0 +1,7 @@
+package no.nav.tag.kontaktskjema.gsak;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface GsakOppgaveRepository extends CrudRepository<GsakOppgave, Integer> {
+    
+}

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
@@ -1,11 +1,16 @@
 package no.nav.tag.kontaktskjema.gsak;
 
 
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.SchedulerLock;
+import no.nav.tag.kontaktskjema.Kontaktskjema;
+import no.nav.tag.kontaktskjema.KontaktskjemaRepository;
 
 @Slf4j
 @Component
@@ -15,9 +20,17 @@ public class GsakScheduler {
 
     private static final String THIRTY_SECONDS = "PT30S";
     
+    @Autowired
+    private KontaktskjemaRepository kontaktskjemaRepository;    
+    
+    @Autowired
+    private GsakOppgaveForSkjema oppgaveForSkjema;    
+    
     @Scheduled(cron = "* * * * * ?")
     @SchedulerLock(name = "navn", lockAtMostForString = ONE_MIN, lockAtLeastForString = THIRTY_SECONDS)
     public void scheduledBehandleSkjemaer() {
-        log.debug("Kjører jobb for gsak");
+        Collection<Kontaktskjema> skjemaer = kontaktskjemaRepository.findAllWithNoGsakOppgave();
+        log.info("Fant {} skjemaer som ikke har gsak-oppgave", skjemaer.size());
+        skjemaer.forEach(oppgaveForSkjema::opprettOppgaveOgLagreStatus);
     }
 }

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
@@ -27,8 +27,8 @@ public class GsakScheduler {
     private GsakOppgaveForSkjema oppgaveForSkjema;    
     
     @Scheduled(cron = "* * * * * ?")
-    @SchedulerLock(name = "navn", lockAtMostForString = ONE_MIN, lockAtLeastForString = THIRTY_SECONDS)
-    public void scheduledBehandleSkjemaer() {
+    @SchedulerLock(name = "opprettOppgaveForSkjemaer", lockAtMostForString = ONE_MIN, lockAtLeastForString = THIRTY_SECONDS)
+    public void scheduledOpprettOppgaveForSkjemaer() {
         Collection<Kontaktskjema> skjemaer = kontaktskjemaRepository.findAllWithNoGsakOppgave();
         log.info("Fant {} skjemaer som ikke har gsak-oppgave", skjemaer.size());
         skjemaer.forEach(oppgaveForSkjema::opprettOppgaveOgLagreStatus);

--- a/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
+++ b/src/main/java/no/nav/tag/kontaktskjema/gsak/GsakScheduler.java
@@ -1,5 +1,6 @@
 package no.nav.tag.kontaktskjema.gsak;
 
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +14,7 @@ public class GsakScheduler {
     private static final String ONE_MIN = "PT14M";
 
     private static final String THIRTY_SECONDS = "PT30S";
-
+    
     @Scheduled(cron = "* * * * * ?")
     @SchedulerLock(name = "navn", lockAtMostForString = ONE_MIN, lockAtLeastForString = THIRTY_SECONDS)
     public void scheduledBehandleSkjemaer() {

--- a/src/main/resources/db/migration/V5__gsak-oppgave.sql
+++ b/src/main/resources/db/migration/V5__gsak-oppgave.sql
@@ -2,5 +2,5 @@ create table GSAK_OPPGAVE (
     id serial primary key,
     kontaktskjema_id number not null ,
     gsak_id number,
-    gsak_status varchar(255),
+    status varchar(255),
 );

--- a/src/main/resources/db/migration/V5__gsak-oppgave.sql
+++ b/src/main/resources/db/migration/V5__gsak-oppgave.sql
@@ -3,4 +3,5 @@ create table GSAK_OPPGAVE (
     kontaktskjema_id number not null ,
     gsak_id number,
     status varchar(255),
+    opprettet timestamp(6) not null default current_timestamp
 );

--- a/src/main/resources/db/migration/V5__gsak-oppgave.sql
+++ b/src/main/resources/db/migration/V5__gsak-oppgave.sql
@@ -1,0 +1,6 @@
+create table GSAK_OPPGAVE (
+    id serial primary key,
+    kontaktskjema_id number not null ,
+    gsak_id number,
+    gsak_status varchar(255),
+);

--- a/src/main/resources/db/migration/V5__gsak-oppgave.sql
+++ b/src/main/resources/db/migration/V5__gsak-oppgave.sql
@@ -3,5 +3,5 @@ create table GSAK_OPPGAVE (
     kontaktskjema_id number not null ,
     gsak_id number,
     status varchar(255),
-    opprettet timestamp(6) not null default current_timestamp
+    opprettet timestamp(6) default current_timestamp
 );

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
@@ -56,5 +56,9 @@ public class KontaktskjemaRepositoryTest {
         return skjema1;
     }
 
-    
+    @Test
+    public void skalHenteSkjemaSomIkkeHarGsakOppgave() {
+        kontaktskjemaRepository.save(lagKontaktskjema());
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+    }
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/KontaktskjemaRepositoryTest.java
@@ -21,6 +21,9 @@ public class KontaktskjemaRepositoryTest {
     @Autowired
     private KontaktskjemaRepository kontaktskjemaRepository;
 
+    @Autowired
+    private Transactor transactor;
+
     @After
     public void tearDown() {
         kontaktskjemaRepository.deleteAll();
@@ -58,7 +61,9 @@ public class KontaktskjemaRepositoryTest {
 
     @Test
     public void skalHenteSkjemaSomIkkeHarGsakOppgave() {
-        kontaktskjemaRepository.save(lagKontaktskjema());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        transactor.inTransaction(() -> {
+            kontaktskjemaRepository.save(lagKontaktskjema());
+            assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        });
     }
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjemaTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjemaTest.java
@@ -1,0 +1,23 @@
+package no.nav.tag.kontaktskjema.gsak;
+
+import static no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus.DISABLED;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import no.nav.tag.kontaktskjema.Kontaktskjema;
+
+public class GsakOppgaveForSkjemaTest {
+
+    @Test
+    public void skalOppdatereDatabaseEtterKallTilGsak() {
+        GsakOppgaveForSkjema gsakOppgaveForSkjema = new GsakOppgaveForSkjema();
+        gsakOppgaveForSkjema.oppgaveRepository = mock(GsakOppgaveRepository.class);
+
+        Kontaktskjema lagKontaktskjema = Kontaktskjema.builder().id(5).build();
+        gsakOppgaveForSkjema.opprettOppgaveOgLagreStatus(lagKontaktskjema);
+
+        verify(gsakOppgaveForSkjema.oppgaveRepository).save(eq(GsakOppgave.builder().kontaktskjemaId(5).status(DISABLED).build()));
+
+    }
+}

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjemaTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveForSkjemaTest.java
@@ -3,8 +3,11 @@ package no.nav.tag.kontaktskjema.gsak;
 import static no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus.DISABLED;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.Test;
 
+import no.nav.tag.kontaktskjema.DateProvider;
 import no.nav.tag.kontaktskjema.Kontaktskjema;
 
 public class GsakOppgaveForSkjemaTest {
@@ -13,11 +16,16 @@ public class GsakOppgaveForSkjemaTest {
     public void skalOppdatereDatabaseEtterKallTilGsak() {
         GsakOppgaveForSkjema gsakOppgaveForSkjema = new GsakOppgaveForSkjema();
         gsakOppgaveForSkjema.oppgaveRepository = mock(GsakOppgaveRepository.class);
-
+        
+        gsakOppgaveForSkjema.dateProvider = mock(DateProvider.class);
+        LocalDateTime now = LocalDateTime.now();
+        when(gsakOppgaveForSkjema.dateProvider.now()).thenReturn(now);
+        
+        
         Kontaktskjema lagKontaktskjema = Kontaktskjema.builder().id(5).build();
         gsakOppgaveForSkjema.opprettOppgaveOgLagreStatus(lagKontaktskjema);
 
-        verify(gsakOppgaveForSkjema.oppgaveRepository).save(eq(GsakOppgave.builder().kontaktskjemaId(5).status(DISABLED).build()));
+        verify(gsakOppgaveForSkjema.oppgaveRepository).save(eq(GsakOppgave.builder().kontaktskjemaId(5).status(DISABLED).opprettet(now).build()));
 
     }
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
@@ -1,0 +1,26 @@
+package no.nav.tag.kontaktskjema.gsak;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class GsakOppgaveRepositoryTest {
+
+    @Autowired
+    private GsakOppgaveRepository repository;
+
+    @Test
+    public void skalLagreOgHenteUt() {
+        GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(1).build());
+        
+        assertThat(repository.findById(lagretOppgave.getId()).isPresent(), is(true));
+    }
+
+}

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 
 import java.time.LocalDateTime;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,11 @@ public class GsakOppgaveRepositoryTest {
     @Autowired
     private GsakOppgaveRepository repository;
 
+    @After
+    public void tearDown() {
+        repository.deleteAll();
+    }
+    
     @Test
     public void skalLagreOgHenteUt() {
         GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(2).status(OK).gsakId(5).opprettet(LocalDateTime.now()).build());

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
@@ -1,5 +1,6 @@
 package no.nav.tag.kontaktskjema.gsak;
 
+import static no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus.OK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -18,9 +19,13 @@ public class GsakOppgaveRepositoryTest {
 
     @Test
     public void skalLagreOgHenteUt() {
-        GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(1).build());
+        GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(2).status(OK).gsakId(5).build());
         
-        assertThat(repository.findById(lagretOppgave.getId()).isPresent(), is(true));
+        GsakOppgave uthentetOppgave = repository.findById(lagretOppgave.getId()).get();
+        assertThat(uthentetOppgave.getId(), greaterThan(0));
+        assertThat(uthentetOppgave.getKontaktskjemaId(), is(2));
+        assertThat(uthentetOppgave.getStatus(), is(OK));
+        assertThat(uthentetOppgave.getGsakId(), is(5));
     }
 
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakOppgaveRepositoryTest.java
@@ -4,6 +4,8 @@ import static no.nav.tag.kontaktskjema.gsak.GsakOppgave.OppgaveStatus.OK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
+import java.time.LocalDateTime;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +21,14 @@ public class GsakOppgaveRepositoryTest {
 
     @Test
     public void skalLagreOgHenteUt() {
-        GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(2).status(OK).gsakId(5).build());
+        GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(2).status(OK).gsakId(5).opprettet(LocalDateTime.now()).build());
         
         GsakOppgave uthentetOppgave = repository.findById(lagretOppgave.getId()).get();
         assertThat(uthentetOppgave.getId(), greaterThan(0));
         assertThat(uthentetOppgave.getKontaktskjemaId(), is(2));
         assertThat(uthentetOppgave.getStatus(), is(OK));
         assertThat(uthentetOppgave.getGsakId(), is(5));
+        assertThat(uthentetOppgave.getOpprettet(), not(nullValue()));
     }
 
 }

--- a/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakSchedulerTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/gsak/GsakSchedulerTest.java
@@ -18,7 +18,7 @@ public class GsakSchedulerTest {
     private JdbcTemplate jdbcTemplate;
 
     @Test
-    public void skalFeileVedLagringAvKontaktskjemaMedForhandsdefinertId() throws InterruptedException {
+    public void skalSjekkeAtShedlockTabellErPopulert() throws InterruptedException {
         Thread.sleep(1500);
         assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM SHEDLOCK", Integer.class), is(1));
     }


### PR DESCRIPTION
Støtte for å hente ut skjemaer som trenger gsak-oppgave og lagre status om oppgaven ble opprettet. Status inneholder referanse til skjemaet, opprettet-tidspunkt, oppgaveid fra gsak og statuskode som kan være OK, FEILET eller DISABLED. Hvis status er FEILET vil vi forsøke igjen, men ikke dersom status er OK eller DISABLED. Foreløpig settes DISABLED inn som default. Dvs. at skjemaer blir behandlet av jobben, men det blir opprettet en rad i status-tabellen som sier at oppretting av gsak-oppgave er slått av.

Jeg la også inn en utility-metode for å hente nå-dato (for å forenkle testing) og en transactor-klasse som gjør det enkelt å kjøre en hvilken som helst funksjon i en transaksjon.