### PR TITLE
Tester oppførsel i APIet ved å gjøre http POST-request

### DIFF
--- a/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
@@ -15,11 +15,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
 public class ApiTest {
+
+    @LocalServerPort
+    private String port;
 
     private static final String OK_KONTAKTSKJEMA_JSON = "{ " +
         "\"bedriftsnavn\": \"testbedrift\"," +
@@ -42,7 +46,7 @@ public class ApiTest {
 
     private HttpRequest createRequest(String body) {
         return HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:8080/kontaktskjema/meldInteresse"))
+                .uri(URI.create("http://localhost:" + port + "/kontaktskjema/meldInteresse"))
                 .header("Accept", "*/*")
                 .header("Accept-Encoding", "gzip, deflate, br")
                 .header("Accept-Language", "nb-NO,nb;q=0.9,no;q=0.8,nn;q=0.7,en-US;q=0.6,en;q=0.5")

--- a/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
@@ -1,0 +1,83 @@
+package no.nav.tag.kontaktskjema;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment=WebEnvironment.DEFINED_PORT)
+public class ApiTest {
+
+    @Test
+    public void postKontaktskjema_OK() throws Exception {
+
+        String body = "{ " +
+            "\"bedriftsnavn\": \"testbedrift\"," +
+            "\"epost\": \"test@testesen.no\"," +
+            "\"etternavn\": \"testesen\"," +
+            "\"fornavn\": \"test\"," +
+            "\"fylke\": \"agder\"," +
+            "\"kommune\": \"Audnedal\"," +
+            "\"kommunenr\": \"1027\"," +
+            "\"telefonnr\": \"1234\"" +
+            "}";
+
+        HttpClient client = HttpClient.newBuilder().build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080/kontaktskjema/meldInteresse"))
+                .header("Accept", "*/*")
+                .header("Accept-Encoding", "gzip, deflate, br")
+                .header("Accept-Language", "nb-NO,nb;q=0.9,no;q=0.8,nn;q=0.7,en-US;q=0.6,en;q=0.5")
+                .header("Cache-Control", "no-cache")
+                .header("Content-Type", "application/json")
+                .POST(BodyPublishers.ofString(body))
+                .build();
+
+        HttpResponse<?> response = client.send(request, BodyHandlers.ofString());
+        assertThat(response.statusCode(), is(200));
+        assertThat(response.body(), is("\"OK\""));
+    }
+
+    @Test
+    public void postKontaktskjema_feil_kommunenr() throws Exception {
+
+        String body = "{ " +
+            "\"bedriftsnavn\": \"testbedrift\"," +
+            "\"epost\": \"test@testesen.no\"," +
+            "\"etternavn\": \"testesen\"," +
+            "\"fornavn\": \"test\"," +
+            "\"fylke\": \"agder\"," +
+            "\"kommune\": \"Audnedal\"," +
+            "\"kommunenr\": \"kommunenr\"," +
+            "\"telefonnr\": \"1234\"" +
+            "}";
+
+        HttpClient client = HttpClient.newBuilder().build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080/kontaktskjema/meldInteresse"))
+                .header("Accept", "*/*")
+                .header("Accept-Encoding", "gzip, deflate, br")
+                .header("Accept-Language", "nb-NO,nb;q=0.9,no;q=0.8,nn;q=0.7,en-US;q=0.6,en;q=0.5")
+                .header("Cache-Control", "no-cache")
+                .header("Content-Type", "application/json")
+                .POST(BodyPublishers.ofString(body))
+                .build();
+
+        HttpResponse<?> response = client.send(request, BodyHandlers.ofString());
+        assertThat(response.statusCode(), is(500));
+        assertThat(response.body(), is(""));
+    }
+    
+}

--- a/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
+++ b/src/test/java/no/nav/tag/kontaktskjema/ApiTest.java
@@ -1,5 +1,7 @@
 package no.nav.tag.kontaktskjema;
 
+import static java.net.http.HttpClient.newBuilder;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -8,7 +10,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,52 +21,27 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(webEnvironment=WebEnvironment.DEFINED_PORT)
 public class ApiTest {
 
+    private static final String OK_KONTAKTSKJEMA_JSON = "{ " +
+        "\"bedriftsnavn\": \"testbedrift\"," +
+        "\"epost\": \"test@testesen.no\"," +
+        "\"etternavn\": \"testesen\"," +
+        "\"fornavn\": \"test\"," +
+        "\"fylke\": \"agder\"," +
+        "\"kommune\": \"Audnedal\"," +
+        "\"kommunenr\": \"1027\"," +
+        "\"telefonnr\": \"1234\"" +
+        "}";
+
     @Test
     public void postKontaktskjema_OK() throws Exception {
 
-        String body = "{ " +
-            "\"bedriftsnavn\": \"testbedrift\"," +
-            "\"epost\": \"test@testesen.no\"," +
-            "\"etternavn\": \"testesen\"," +
-            "\"fornavn\": \"test\"," +
-            "\"fylke\": \"agder\"," +
-            "\"kommune\": \"Audnedal\"," +
-            "\"kommunenr\": \"1027\"," +
-            "\"telefonnr\": \"1234\"" +
-            "}";
-
-        HttpClient client = HttpClient.newBuilder().build();
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:8080/kontaktskjema/meldInteresse"))
-                .header("Accept", "*/*")
-                .header("Accept-Encoding", "gzip, deflate, br")
-                .header("Accept-Language", "nb-NO,nb;q=0.9,no;q=0.8,nn;q=0.7,en-US;q=0.6,en;q=0.5")
-                .header("Cache-Control", "no-cache")
-                .header("Content-Type", "application/json")
-                .POST(BodyPublishers.ofString(body))
-                .build();
-
-        HttpResponse<?> response = client.send(request, BodyHandlers.ofString());
+        HttpResponse<?> response = newBuilder().build().send(createRequest(OK_KONTAKTSKJEMA_JSON), ofString());
         assertThat(response.statusCode(), is(200));
         assertThat(response.body(), is("\"OK\""));
     }
 
-    @Test
-    public void postKontaktskjema_feil_kommunenr() throws Exception {
-
-        String body = "{ " +
-            "\"bedriftsnavn\": \"testbedrift\"," +
-            "\"epost\": \"test@testesen.no\"," +
-            "\"etternavn\": \"testesen\"," +
-            "\"fornavn\": \"test\"," +
-            "\"fylke\": \"agder\"," +
-            "\"kommune\": \"Audnedal\"," +
-            "\"kommunenr\": \"kommunenr\"," +
-            "\"telefonnr\": \"1234\"" +
-            "}";
-
-        HttpClient client = HttpClient.newBuilder().build();
-        HttpRequest request = HttpRequest.newBuilder()
+    private HttpRequest createRequest(String body) {
+        return HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:8080/kontaktskjema/meldInteresse"))
                 .header("Accept", "*/*")
                 .header("Accept-Encoding", "gzip, deflate, br")
@@ -74,10 +50,16 @@ public class ApiTest {
                 .header("Content-Type", "application/json")
                 .POST(BodyPublishers.ofString(body))
                 .build();
+    }
+    
+    @Test
+    public void postKontaktskjema_feil_kommunenr() throws Exception {
 
-        HttpResponse<?> response = client.send(request, BodyHandlers.ofString());
+        String bodyMedForLangtKommunenr = OK_KONTAKTSKJEMA_JSON.replaceFirst("1027", "10127");
+
+        HttpResponse<?> response = HttpClient.newBuilder().build().send(createRequest(bodyMedForLangtKommunenr), ofString());
         assertThat(response.statusCode(), is(500));
         assertThat(response.body(), is(""));
     }
-    
+
 }


### PR DESCRIPTION
Enkle tester som gjør faktiske http POST-kall mot APIet og sjekker http-kode og body i responsen.

Et slikt test-regime kan være en enkel måte å teste at APIet vårt fungerer slik som klienten(e) forventer, a la pact. Kan utvides til å teste flere ulike http-koder, innlogging osv.

~~Akkurat nå fungerer testen når den kjører for seg selv, men ikke dersom alle testene kjører samtidig.~~
Dette løste seg ved å bruke `WebEnvironment.RANDOM_PORT`